### PR TITLE
Fix for the potential fps drops in the DamagedPlayer event

### DIFF
--- a/scripts/HudAnimations_tf.txt
+++ b/scripts/HudAnimations_tf.txt
@@ -4,6 +4,12 @@
 
 event DamagedPlayer
 {
+    StopEvent CrosshairCircle 0.0
+	RunEvent CrossHairCircle 0.01
+}
+
+event CrosshairCircle
+{
     Animate CrossHairCircle 	FgColor 	"CrosshairDamage" 	Linear 0.0 0.00001
 	Animate CrossHairCircle 	FgColor 	"White" 	Linear 0.10 0.10001
 }
@@ -14,7 +20,13 @@ event DamagedPlayer
 
 event DamagedPlayer
 {
-	Animate fogCrosshair 	FgColor 	"CrosshairDamage" 	Linear 0.0 0.00001
+	StopEvent fogsCrosshair 0.0
+	RunEvent fogsCrosshair 0.01
+}
+
+event fogsCrosshair
+{
+    Animate fogCrosshair 	FgColor 	"CrosshairDamage" 	Linear 0.0 0.00001
 	Animate fogCrosshair 	FgColor 	"Crosshair" 	Linear 0.10 0.10001
 	
 	// Set the second line ("255 255 255 255") to whatever color you have changed


### PR DESCRIPTION
Details of the "problem" and this solution can be found on [huds.tf](http://huds.tf/forum/showthread.php?tid=345) and [this Reddit post](https://www.reddit.com/r/tf2/comments/57760o/cause_and_fix_for_serious_fpsdrop_issue_involving/)

tl;dr : This prevents stacking of animations (and fps drops) when dealing a lot of damage (for example with pyro's flamethrower).
