### PR TITLE
Fixed Huntsman and Stickybomb charge meter

### DIFF
--- a/resource/ui/HudBowCharge.res
+++ b/resource/ui/HudBowCharge.res
@@ -1,22 +1,5 @@
 "Resource/UI/HudBowCharge.res"
 {
-	"ChargeLabel"
-	{
-		"ControlName"			"CExLabel"
-		"fieldName"				"ChargeLabel"
-		"xpos"			"0"
-		"ypos"			"23"
-		"zpos"			"10"
-		"wide"			"120"
-		"tall"			"8"
-		"pinCorner"				"2"
-		"visible"				"1"
-		"enabled"				"1"
-		"fgcolor_override" "White"
-		"labelText"				"BOW"
-		"textAlignment"			"west"
-		"font"					"solFontRegular8"
-	}	
 	"ChargeMeter"
 	{	
 		"ControlName"	"ContinuousProgressBar"

--- a/resource/ui/HudDemomanCharge.res
+++ b/resource/ui/HudDemomanCharge.res
@@ -13,7 +13,7 @@
 		"visible"				"1"
 		"enabled"				"1"
 		"fgcolor_override"      "White"
-		"labelText"				"BOMB"
+		"labelText"				"#TF_Charge"
 		"textAlignment"			"west"
 		"font"					"solFontRegular8"
 	}	


### PR DESCRIPTION
Fixed the Stickybomb charge label "BOMB" overlapping the Huntsman charge "BOW".
Done by changing the words "BOMB" and "BOW" to "CHARGE".  
  
  
(forgot how to crop images on mac lol so you're gonna have to zoom in sorry)

BEFORE:
<img width="1680" alt="Screen Shot 2019-08-31 at 1 34 51 PM" src="https://user-images.githubusercontent.com/38830741/64057723-b58ebc80-cbf4-11e9-9d21-f2b3487023fd.png">

AFTER:
<img width="1680" alt="Screen Shot 2019-08-31 at 1 35 06 PM" src="https://user-images.githubusercontent.com/38830741/64057724-b9224380-cbf4-11e9-8749-64c894c6cc25.png">
